### PR TITLE
IdeaThreads refactor

### DIFF
--- a/app/collections/ideas_collection.coffee
+++ b/app/collections/ideas_collection.coffee
@@ -31,7 +31,7 @@ module.exports = class Ideas extends Collection
     existing = @findWhere
       id: data.id
     if existing
-      data = _.pick(data, ['title', 'description', 'when'])
+      data = _.pick(data, ['title', 'description', 'expiration', 'description'])
       existing.set data
       @updateModel existing
     else

--- a/app/controllers/idea_threads_controller.coffee
+++ b/app/controllers/idea_threads_controller.coffee
@@ -36,8 +36,8 @@ module.exports = class IdeaThreadsController extends Controller
         @view = new IdeaThreadView model: @model, region: 'main', autoRender: true
         @adjustTitle @model.get('title')
 
-  update: (model, ideas_collection, ideas_collection_view, attrs) ->
-    model.save attrs,
+  update: (model) ->
+    model.save model.attributes,
       error: (model, response) =>
         console.log $.parseJSON(response.responseText)
         @publishEvent 'renderError', response

--- a/app/lib/view-helper.coffee
+++ b/app/lib/view-helper.coffee
@@ -62,6 +62,8 @@ Handlebars.registerHelper 'displayName', (user) ->
 Handlebars.registerHelper 'hasPermission', (user_id, options) ->
   if user_id == Chaplin.mediator.user.get('id')
     options.fn(this)
+  else
+    options.inverse this
 
 Handlebars.registerHelper 'unlessCurrentUser', (user_id, options) ->
   unless user_id == Chaplin.mediator.user.get('id')

--- a/app/models/idea.coffee
+++ b/app/models/idea.coffee
@@ -16,6 +16,8 @@ module.exports = class Idea extends Model
     votes = new VotesCollection(@get 'votes')
     votes.idea = @
     @set 'votes', votes
+    @listenTo @, 'change:updated_at', =>
+      @set 'edited', false
 
   hasVote: (vote_id) ->
     votes = @get('votes')

--- a/app/models/idea_thread.coffee
+++ b/app/models/idea_thread.coffee
@@ -21,15 +21,15 @@ module.exports = class IdeaThread extends Model
       voting_rights.add
         user_id: current_user_id
         autocomplete_value: current_user_id
-      vote = new Vote
-      idea = new Idea
       @set 'ideas', ideas
       @set 'voting_rights', voting_rights
     else
       if _.isArray(@get('voting_rights'))
         voting_rights = new VotingRightsCollection(@get('voting_rights'))
         @set 'voting_rights', voting_rights
-
+      if _.isArray(@get('ideas'))
+        ideas = new IdeasCollection(@get('ideas'))
+        @set 'ideas', ideas
 
 
   total_votes: ->
@@ -45,8 +45,11 @@ module.exports = class IdeaThread extends Model
       0
 
   parse: (idea_thread) ->
-    ideas = idea_thread.ideas
-    idea_thread.ideas = new IdeasCollection(ideas)
+    if idea_thread.ideas.length > 0
+      ideas = idea_thread.ideas
+      idea_thread.ideas = new IdeasCollection(ideas)
+    else
+      idea_thread.ideas = new IdeasCollection()
     voting_rights = idea_thread.voting_rights
     idea_thread.voting_rights = new VotingRightsCollection(voting_rights)
     return idea_thread
@@ -59,7 +62,8 @@ module.exports = class IdeaThread extends Model
     delete new_attr.ideas
     delete new_attr.voting_rights
     json = {idea_thread : new_attr}
-    _.extend json.idea_thread, {ideas_attributes: ideas, voting_rights_attributes: voting_rights}
+    _.extend json.idea_thread, {voting_rights_attributes: voting_rights}
+    _.extend json.idea_thread, {ideas_attributes: ideas} if ideas.length
     return json
 
   userCanVote: (user_id) ->

--- a/app/models/notifier.coffee
+++ b/app/models/notifier.coffee
@@ -29,10 +29,11 @@ module.exports = class Notifier extends Model
       PrivatePub.subscribe "/message/channel", (data, channel) =>
         payload = jQuery.parseJSON(data.message)
         model_name = payload.model_name
-        delete payload.model_name
-        @notifyApp(model_name, payload)
-        @createWebNotification(model_name, payload) if mediator.user.get('notifications')
-        @createAudioNotification(model_name, payload) if "webkitAudioContext" of window
+        unless payload.user_id is Chaplin.mediator.user.get('id')
+          delete payload.model_name
+          @notifyApp(model_name, payload)
+          @createWebNotification(model_name, payload) if mediator.user.get('notifications')
+          @createAudioNotification(model_name, payload) if "webkitAudioContext" of window
 
 
   notifyApp: (model_name, payload) ->

--- a/app/views/base/view.coffee
+++ b/app/views/base/view.coffee
@@ -51,13 +51,9 @@ module.exports = class View extends Chaplin.View
     if @textBindings
       attributes = _.keys model.changed
       _.each attributes, (attr) =>
-        $el = @$el.find("[data-bind='#{attr}']")
+        $el = @$el.find("[data-bind='#{attr}']:first")
         if $el.length
           if @model.get(attr) is undefined
             $el.text ''
           else
-            if attr is 'when'
-              timely = moment(@model.get(attr)).calendar()
-              $el.text timely
-            else
-              $el.text @model.get(attr)
+            $el.text @model.get(attr)

--- a/app/views/form_elements/date_input_view.coffee
+++ b/app/views/form_elements/date_input_view.coffee
@@ -15,6 +15,9 @@ module.exports = module.exports = class DateInputView extends View
   render: ->
     super
     @$el.attr('name', @attribute)
+    attr_val = @model.get(@attribute)
+    if attr_val
+      @$el.val moment(attr_val).calendar()
 
   translateDate: ->
     input_val = @$el.val()

--- a/app/views/idea_threads/idea_thread_view.coffee
+++ b/app/views/idea_threads/idea_thread_view.coffee
@@ -15,7 +15,7 @@ module.exports = class IdeaThreadView extends View
   regions:
     ideas: '.ideas'
     voters: '.voters'
-  textBindings: true
+  # textBindings: true
   events:
     'click .archive': 'archive'
     'click .destroy': 'destroyThread'

--- a/app/views/idea_threads/idea_thread_view.coffee
+++ b/app/views/idea_threads/idea_thread_view.coffee
@@ -106,6 +106,7 @@ module.exports = class IdeaThreadView extends View
     # attrs = _.clone @model.attributes
     # @publishEvent 'save_idea_thread', @model, @ideas, @collection_view, @
     @model.save()
+    @dispose() if @model.isNew()
 
   archive: (e) ->
     e.preventDefault()

--- a/app/views/idea_threads/idea_threads_collection_view.coffee
+++ b/app/views/idea_threads/idea_threads_collection_view.coffee
@@ -30,11 +30,17 @@ module.exports = class IdeaThreadsCollectionView extends CollectionView
     @subscribeEvent 'save_idea_thread', @cleanup
     @subscribeEvent 'escapeForm', @cleanup
     @subscribeEvent 'reset_top_level_keys', @setupKeyBindings
+    @listenTo @collection, 'dispose', @cleanup
+    @listenTo @collection, 'change:updated_at', (model) =>
+      @filter @filterer, (view, included) ->
+        unless included
+          view.$el.hide()
+
 
   newIdeaThread: (e) ->
     if @new_idea_thread
       new_idea_thread_view = @viewForModel(@new_idea_thread)
-      @$el.find("input[name='title']").focus()
+      new_idea_thread_view.$el.find("input[name='title']").focus()
     else
       current_user_id = @current_user.get('id')
       ideas = new IdeasCollection()
@@ -45,18 +51,11 @@ module.exports = class IdeaThreadsCollectionView extends CollectionView
       @collection.add(@new_idea_thread, {at: 0})
 
 
-  cleanup: ->
-    empty_thread = @collection.find (thread) ->
-      thread.get('ideas').models.length is 0
-    empty_thread.dispose() if empty_thread
-
+  cleanup: (a,b,c) ->
     @new_idea_thread = null
     @setupKeyBindings()
 
   initItemView: (model) ->
-    if model.isNew()
-      new IdeaThreadView model: model, collection_view: @
-    else
-      new IdeaThreadView model: model, collection_view: @
+    new IdeaThreadView model: model, collection_view: @
 
 

--- a/app/views/idea_threads/templates/collection.hbs
+++ b/app/views/idea_threads/templates/collection.hbs
@@ -1,6 +1,6 @@
 <div class="collection">
   <div class="header">
-    <div class="headerAction"><button class='add'>Add</button></div>
+    <div class="headerAction"><button class='add'>Add a Thread</button></div>
     <div class="headerTitle"><h1>Ideas</h1></div>
   </div>
   <div class='collectionItems'>

--- a/app/views/idea_threads/templates/show.hbs
+++ b/app/views/idea_threads/templates/show.hbs
@@ -1,12 +1,19 @@
 {{#hasPermission user_id }}
+
+  {{#unless id}}
+    <button class="flyout cancel">
+      <div class="flyoutIcon"></div>
+      <div class="flyoutTray">
+        <div class="flyoutText"></div>
+      </div>
+    </button>
+  {{/unless}}
+
   <h1><input name='title' placeholder="Topic"  autofocus /></h1>
-{{else}}
-  <h1 data-bind='title'>{{title}}</h1>
-{{/hasPermission}}
-</h1>
-{{#hasPermission user_id }}
   <input class='text-expiration' placeholder='expires on...'>
   <input type='hidden' name='expiration'/>
+{{else}}
+  <h1 data-bind='title'>{{title}}</h1>
 {{/hasPermission}}
 <small class='date-helper'></small>
 <br/>
@@ -23,12 +30,13 @@
 {{#hasPermission user_id }}
   {{#if id}}
     <a href='#' class='archive'>ARCHIVE</a>
+    <a href='#' class='destroy'>DESTROY</a>
   {{/if}}
 {{/hasPermission}}
 
 <div class='voters'></div>
-
-<div class='ideas'></div>
-{{#unless id }}
+{{#if id}}
+  <div class='ideas'></div>
+{{else}}
   <button class="submit">Submit</button>
-{{/unless}}
+{{/if}}

--- a/app/views/idea_threads/templates/show.hbs
+++ b/app/views/idea_threads/templates/show.hbs
@@ -1,6 +1,9 @@
 <h1>
   <input data-bind='title' name='title' placeholder="Topic"  autofocus />
 </h1>
+<input class='text-expiration' placeholder='expires on...'>
+<input type='hidden' name='expiration'/>
+<small class='date-helper'></small>
 {{#if id}}
   <a href="/ideas/{{id}}" class='permalink'>Permalink</a>
 {{/if}}

--- a/app/views/idea_threads/templates/show.hbs
+++ b/app/views/idea_threads/templates/show.hbs
@@ -1,9 +1,21 @@
-<h1>
-  <input data-bind='title' name='title' placeholder="Topic"  autofocus />
+{{#hasPermission user_id }}
+  <h1><input name='title' placeholder="Topic"  autofocus /></h1>
+{{else}}
+  <h1 data-bind='title'>{{title}}</h1>
+{{/hasPermission}}
 </h1>
-<input class='text-expiration' placeholder='expires on...'>
-<input type='hidden' name='expiration'/>
+{{#hasPermission user_id }}
+  <input class='text-expiration' placeholder='expires on...'>
+  <input type='hidden' name='expiration'/>
+{{/hasPermission}}
 <small class='date-helper'></small>
+<br/>
+{{#hasPermission user_id }}
+  <textarea name='description' placeholder='description'></textarea>
+{{else}}
+  <p data-bind='description'>{{ description }}</p>
+{{/hasPermission}}
+<br/>
 {{#if id}}
   <a href="/ideas/{{id}}" class='permalink'>Permalink</a>
 {{/if}}
@@ -17,3 +29,6 @@
 <div class='voters'></div>
 
 <div class='ideas'></div>
+{{#unless id }}
+  <button class="submit">Submit</button>
+{{/unless}}

--- a/app/views/ideas/idea_edit_view.coffee
+++ b/app/views/ideas/idea_edit_view.coffee
@@ -10,8 +10,6 @@ module.exports = class IdeaEditView extends View
   events:
     'click .submit': 'save'
     'click .cancel': 'exit'
-  listen:
-    'change model': 'displayWhen'
 
   initialize: (options) ->
     super
@@ -20,10 +18,6 @@ module.exports = class IdeaEditView extends View
   render: ->
     super
     Mousetrap.unbind('n')
-    @natural_input = new DateInputView
-      model: @model
-      attr: 'when'
-      el: @$el.find('.natural-language')
 
   exit: ->
     @collection_view.escapeForm @model
@@ -33,14 +27,6 @@ module.exports = class IdeaEditView extends View
   save: ->
     @updateModelFromFields =>
       @collection_view.save(@model)
-
-  displayWhen: (model) ->
-    changed = _.keys model.changed
-    if changed.indexOf('when') > -1
-      if model.changed.when is undefined or model.changed.when is null
-        @$el.find('.when').text('')
-      else
-        @$el.find('.when').text moment(@model.get('when')).format("dddd MMM D, ha")
 
   updateModelFromFields: (callback) ->
     description = @$el.find("[name='description']").val()

--- a/app/views/ideas/idea_edit_view.coffee
+++ b/app/views/ideas/idea_edit_view.coffee
@@ -25,7 +25,8 @@ module.exports = class IdeaEditView extends View
 
   save: ->
     @updateModelFromFields =>
-      @collection_view.save(@model)
+      @model.save()
+      # @collection_view.save(@model)
 
   updateModelFromFields: (callback) ->
     description = @$el.find("[name='description']").val()

--- a/app/views/ideas/idea_edit_view.coffee
+++ b/app/views/ideas/idea_edit_view.coffee
@@ -25,8 +25,7 @@ module.exports = class IdeaEditView extends View
 
   save: ->
     @updateModelFromFields =>
-      @model.save()
-      # @collection_view.save(@model)
+      @collection_view.save(@model)
 
   updateModelFromFields: (callback) ->
     description = @$el.find("[name='description']").val()

--- a/app/views/ideas/idea_edit_view.coffee
+++ b/app/views/ideas/idea_edit_view.coffee
@@ -13,19 +13,19 @@ module.exports = class IdeaEditView extends View
   initialize: (options) ->
     super
     @collection_view = options.collection_view
+    @listenTo @model, 'change:id', @dispose
 
   render: ->
     super
     Mousetrap.unbind('n')
 
   exit: ->
-    @collection_view.escapeForm @model
     @collection_view.setupKeyBindings()
-    @publishEvent 'escapeForm'
+    @model.set('edited', false)
 
   save: ->
     @updateModelFromFields =>
-      @collection_view.save(@model)
+      @model.save()
 
   updateModelFromFields: (callback) ->
     description = @$el.find("[name='description']").val()

--- a/app/views/ideas/idea_edit_view.coffee
+++ b/app/views/ideas/idea_edit_view.coffee
@@ -1,5 +1,4 @@
 View = require 'views/base/form_view'
-DateInputView = require 'views/form_elements/date_input_view'
 
 module.exports = class IdeaEditView extends View
   template: require './templates/edit'

--- a/app/views/ideas/idea_view.coffee
+++ b/app/views/ideas/idea_view.coffee
@@ -36,7 +36,7 @@ module.exports = class IdeaView extends View
 
   edit: (e) ->
     e.preventDefault()
-    @collection_view.editIdea @model
+    @model.set('edited', true)
 
   vote: (e) ->
     if @user_vote
@@ -69,11 +69,7 @@ module.exports = class IdeaView extends View
 
   destroy: (e) ->
     e.preventDefault() if e
-    @model.destroy
-      success: (idea,b) =>
-        @collection_view.collection.remove(idea)
-        console.log @collection_view.collection
-        @collection_view.checkEmpty()
+    @model.destroy()
 
   renderViewInCollection: (object) ->
     changed = _.keys(object.changed)

--- a/app/views/ideas/ideas_collection_view.coffee
+++ b/app/views/ideas/ideas_collection_view.coffee
@@ -24,9 +24,7 @@ module.exports = class IdeasCollectionView extends CollectionView
     @thread_view = options.thread_view
     @thread_id   = @thread_view.model.get('id')
     @subscribeEvent 'reset_top_level_keys', @setupKeyBindings
-    @subscribeEvent 'save_idea', @escapeForm
     @listenTo @collection, 'change:edited', @handleEdit
-    @listenTo @collection, 'change:id', @renderItem
 
   newIdea: (e) ->
     e.preventDefault() if e
@@ -39,13 +37,17 @@ module.exports = class IdeasCollectionView extends CollectionView
 
     @collection.add idea, {at: idea_count + 1}
 
-  editIdea: (model) ->
-    @removeViewForItem(model)
-    @updateVisibleItems model, true
-    model.set 'edited', true
 
-  handleEdit: (model) ->
-    @renderAllItems()
+  handleEdit: (model, edited) ->
+    if edited
+      @reRender(model)
+    else
+      @escapeForm(model)
+
+  reRender: (model) ->
+    @removeViewForItem(model)
+    view = @initItemView(model)
+    @insertView(model, view)
 
   escapeForm: (idea) ->
     @thread_view.$el.removeClass('syncing') if @thread_view.$el
@@ -84,10 +86,11 @@ module.exports = class IdeasCollectionView extends CollectionView
 
   save: (model) ->
     @thread_view.$el.addClass('syncing')
-    if @thread_view.model.isNew()
-      @thread_view.save()
-    else
-      @publishEvent 'save_idea', model, @collection, @
+    model.save model.attributes,
+      success: =>
+        console.log 'SUCESSSSSS'
+        console.log model
+        @renderItem(model)
 
   resort: ->
     @collection.sort()

--- a/app/views/ideas/ideas_collection_view.coffee
+++ b/app/views/ideas/ideas_collection_view.coffee
@@ -24,9 +24,9 @@ module.exports = class IdeasCollectionView extends CollectionView
     @thread_view = options.thread_view
     @thread_id   = @thread_view.model.get('id')
     @subscribeEvent 'reset_top_level_keys', @setupKeyBindings
-    @subscribeEvent 'escapeForm', @checkEmpty
     @subscribeEvent 'save_idea', @escapeForm
     @listenTo @collection, 'change:edited', @handleEdit
+    @listenTo @collection, 'change:id', @renderItem
 
   newIdea: (e) ->
     e.preventDefault() if e
@@ -52,7 +52,6 @@ module.exports = class IdeasCollectionView extends CollectionView
     @new_idea = null
 
     if idea
-
       @removeViewForItem(idea)
       if idea.isNew()
         @collection.remove(idea)
@@ -63,7 +62,6 @@ module.exports = class IdeasCollectionView extends CollectionView
     else
       @collection.remove(@new_idea)
       @new_idea = null
-      @checkEmpty()
 
     @editing_view.dispose() if @editing_view
     @editing_view = null
@@ -93,11 +91,3 @@ module.exports = class IdeasCollectionView extends CollectionView
 
   resort: ->
     @collection.sort()
-
-  checkEmpty: ->
-    if @collection.size() == 0
-      if @thread_view.model
-        if @thread_view.model.isNew()
-          @thread_view.model.dispose()
-        else
-          @thread_view.model.destroy()

--- a/app/views/ideas/templates/edit.hbs
+++ b/app/views/ideas/templates/edit.hbs
@@ -25,17 +25,6 @@
       </div>
     </div>
   </div>
-  <div class="formColumn">
-    <div class="labelField">
-      <div class="labelFieldLabel">
-        <label>When:</label>
-      </div>
-      <div class="labelFieldInput">
-        <input class="mousetrap natural-language" type="datetime" />
-        <small class="when"></small>
-      </div>
-    </div>
-  </div>
 </div>
 <div class="formRow">
   <div class="formColumn">

--- a/app/views/ideas/templates/show.hbs
+++ b/app/views/ideas/templates/show.hbs
@@ -3,7 +3,7 @@
     <img class="avatar" src="{{ gravatar user.email }}" alt="{{ displayName user }}" title="{{ displayName user }}">
   </div>
   <div class="ideaInfo">
-    <h2 class="ideaTitle" ><span data-bind='title'>{{ title }}</span> {{#if when}}<span class="ideaTitleWhen" data-bind='when'>— {{#timely}}{{ when }}{{/timely}}</span>{{/if}}</h2>
+    <h2 class="ideaTitle" ><span data-bind='title'>{{ title }}</span></h2>
     {{#if description}}<p data-bind='description' class="ideaDescription">{{ description }}</p>{{/if}}
   </div>
   <div class="ideaAction">


### PR DESCRIPTION
Pretty major overhaul of IdeaThread views. Puts listeners in the collection instead of the view. Re-renders at the correct times.
- Adds description and expiration date fields
- Better editing without view duplication
- Forces creation of Thread first, then Ideas. 
- Adds delete action and save button to Threads
