### PR TITLE
Archives 84 rb

### DIFF
--- a/app/collections/votes_collection.coffee
+++ b/app/collections/votes_collection.coffee
@@ -7,6 +7,7 @@ module.exports = class Votes extends Collection
     Chaplin.mediator.apiURL('/votes')
   initialize: (options) ->
     super
+    @current_user = Chaplin.mediator.user
     @subscribeEvent 'notifier:update_vote', @updateVote
 
   updateVote: (data) ->
@@ -26,3 +27,18 @@ module.exports = class Votes extends Collection
     if vote
       @remove(vote)
 
+  currentUserVote: ->
+    @findWhere
+      user_id: @current_user.get('id')
+
+  voteOnIdea: (idea_id) ->
+    if @currentUserVote()
+      @currentUserVote().destroy()
+    else
+      @create
+        user_id: @current_user.get('id')
+        idea_id: idea_id
+        user_name: @current_user.display_name
+        user:
+          email: @current_user.get('email')
+          id: @current_user.get('id')

--- a/app/controllers/idea_threads_controller.coffee
+++ b/app/controllers/idea_threads_controller.coffee
@@ -28,6 +28,13 @@ module.exports = class IdeaThreadsController extends Controller
     @view = new IdeaThreadsCollectionView collection: @collection, region: 'main'
     @adjustTitle('Dashboard')
 
+  archive: ->
+    @collection = new IdeaThreads()
+    @collection.url = Chaplin.mediator.apiURL('/idea_threads/archives')
+    @collection.fetch()
+    @view = new IdeaThreadsCollectionView collection: @collection, region: 'main', archives: true
+    @adjustTitle('Archive')
+
   show: (params) ->
     @model = new IdeaThread
       id: params.id

--- a/app/lib/view-helper.coffee
+++ b/app/lib/view-helper.coffee
@@ -65,6 +65,12 @@ Handlebars.registerHelper 'hasPermission', (user_id, options) ->
   else
     options.inverse this
 
+Handlebars.registerHelper 'isArchivable', (status, options) ->
+  if status != 'archived'
+    options.fn(this)
+  else
+    options.inverse this
+
 Handlebars.registerHelper 'unlessCurrentUser', (user_id, options) ->
   unless user_id == Chaplin.mediator.user.get('id')
     options.fn(this)

--- a/app/models/idea.coffee
+++ b/app/models/idea.coffee
@@ -41,6 +41,13 @@ module.exports = class Idea extends Model
     else
       return false
 
+  performUserVote: ->
+    @publishEvent 'find_thread', @get('idea_thread_id'), (thread) =>
+      if thread.isVotable()
+        @get('votes').voteOnIdea(@get('id'))
+      else
+        @publishEvent 'flash_message', "Voting on #{thread.get('title')} is closed"
+
   parse: (idea) ->
     # ActivitiesCollection arguements: Items, Idea, Collection Limit
     activities = new ActivitiesCollection(idea.recent_activities, @, 10)

--- a/app/models/idea_thread.coffee
+++ b/app/models/idea_thread.coffee
@@ -14,6 +14,7 @@ module.exports = class IdeaThread extends Model
 
   initialize: ->
     super
+
     if @isNew()
       current_user_id = Chaplin.mediator.user.get('id')
       ideas = new IdeasCollection()
@@ -43,6 +44,12 @@ module.exports = class IdeaThread extends Model
         memo + num
     else
       0
+
+  isVotable: ->
+    if @get('status') is 'open'
+      return true
+    else
+      return false
 
   parse: (idea_thread) ->
     if idea_thread.ideas.length > 0

--- a/app/routes.coffee
+++ b/app/routes.coffee
@@ -15,6 +15,7 @@ module.exports = (match) ->
 
   # match 'ideas', 'ideas#index'
   match 'ideas', 'idea_threads#index', name: 'ideas'
+  match 'ideas/archives', 'idea_threads#archive', name: 'ideas_archives'
   match 'ideas/:id', 'idea_threads#show', name: 'idea'
 
   match 'groups', 'groups#index'

--- a/app/views/idea_threads/idea_threads_collection_view.coffee
+++ b/app/views/idea_threads/idea_threads_collection_view.coffee
@@ -20,12 +20,16 @@ module.exports = class IdeaThreadsCollectionView extends CollectionView
   key_bindings:
     'n': 'newIdeaThread'
   filterer: (item, index) ->
-    if item.get('status') is 'archived'
-      return false
-    else
+    if @archives
       return true
+    else
+      if item.get('status') is 'archived'
+        return false
+      else
+        return true
 
-  initialize: ->
+  initialize: (options) ->
+    @archives = options.archives
     super
     @subscribeEvent 'save_idea_thread', @cleanup
     @subscribeEvent 'escapeForm', @cleanup

--- a/app/views/idea_threads/templates/show.hbs
+++ b/app/views/idea_threads/templates/show.hbs
@@ -29,7 +29,7 @@
 <br/><br/>
 {{#hasPermission user_id }}
   {{#if id}}
-    <a href='#' class='archive'>ARCHIVE</a>
+    {{#isArchivable status}}<a href='#' class='archive'>ARCHIVE</a>{{/isArchivable}}
     <a href='#' class='destroy'>DESTROY</a>
   {{/if}}
 {{/hasPermission}}

--- a/app/views/ideas/idea_view.coffee
+++ b/app/views/ideas/idea_view.coffee
@@ -32,6 +32,7 @@ module.exports = class IdeaView extends View
     super
     @createVotesView()
     @createActivitiesView()
+    @updateVoteButtonUI()
 
     @listenTo @votes, 'add', @updateVotesCount
     @listenTo @votes, 'remove', @updateVotesCount
@@ -58,33 +59,20 @@ module.exports = class IdeaView extends View
     @subview('activity_feed').viewAll()
 
   vote: (e) ->
-    if @user_vote
-      @user_vote.destroy()
-    else
-      current_user = Chaplin.mediator.user
-      vote = new Vote
-        user_id: current_user.get('id')
-        idea_id: @model.get('id')
-        user_name: current_user.display_name
-        user:
-          email: current_user.get('email')
-          id: current_user.get('id')
-      @$el.find(".vote").addClass('voted')
-      vote.save vote.attributes,
-        success: (vote) =>
-          @votes.add(vote)
-
-  toggleUserVote: (voted, user_vote) ->
-    if voted
-      @$el.find(".vote").addClass('voted')
-      @user_vote = user_vote
-    else
-      @$el.find(".vote").removeClass('voted')
-      @user_vote = null
+    e.preventDefault()
+    console.log 'click'
+    @model.performUserVote()
 
   updateVotesCount: ->
+    @updateVoteButtonUI()
     @model.set('total_votes', @votes.length)
     @collection_view.resort()
+
+  updateVoteButtonUI: ->
+    if @votes.currentUserVote()
+      @$el.find('button.vote').addClass('voted')
+    else
+      @$el.find('button.vote').removeClass('voted')
 
 
   destroy: (e) ->

--- a/app/views/ideas/idea_view.coffee
+++ b/app/views/ideas/idea_view.coffee
@@ -60,7 +60,6 @@ module.exports = class IdeaView extends View
 
   vote: (e) ->
     e.preventDefault()
-    console.log 'click'
     @model.performUserVote()
 
   updateVotesCount: ->

--- a/app/views/layout/templates/header.hbs
+++ b/app/views/layout/templates/header.hbs
@@ -7,6 +7,9 @@
       <a href='/groups'>My Groups</a>
     </li>
     <li>
+      <a href='/ideas/archives'>Archives</a>
+    </li>
+    <li>
       <a href='/logout'>Logout</a>
     </li>
   {{else}}

--- a/app/views/votes/votes_collection_view.coffee
+++ b/app/views/votes/votes_collection_view.coffee
@@ -5,19 +5,7 @@ module.exports = class VotesView extends View
   # template: require './templates/collection'
   itemView: VoteView
   animationDuration: 0
-  listen:
-    'add collection': 'checkUserVote'
-    'remove collection': 'checkUserVote'
 
   initialize: (options) ->
     super
     @idea_view = options.idea_view
-    @checkUserVote()
-
-  checkUserVote: (model) ->
-    user_vote = @collection.findWhere
-      user_id: Chaplin.mediator.user.get('id')
-    if user_vote
-      @idea_view.toggleUserVote(true, user_vote)
-    else
-      @idea_view.toggleUserVote(false)

--- a/test/views/ideas-collection-view-test.coffee
+++ b/test/views/ideas-collection-view-test.coffee
@@ -40,6 +40,7 @@ describe 'IdeasCollectionView', ->
     @collection = new Ideas
     @view = new IdeasCollectionView
       collection: @collection
+      region: 'ideas'
       thread_view: @thread_view
 
   afterEach ->


### PR DESCRIPTION
- [x] Route for `/ideas/archives => IdeaThreadsController#archives`
- [x] Update IdeaThreadCollectionView to only apply archive filter on the dashboard, not the archive page
- [x] Don't show archived link on Archived IdeaThreads
- [x] Disabling voting on Archived threads.
  - Refactor of the actual voting method. Moved out of view into
    Idea Model to do the check. VotesCollection actually creates
    the vote. Cleans up view considerably.
  - Checks IdeaThread's status before adding or removing a vote.
