### PR TITLE
Giving User the ability to remove themselves from an IdeaThread

### DIFF
--- a/app/collections/idea_threads_collection.coffee
+++ b/app/collections/idea_threads_collection.coffee
@@ -27,6 +27,8 @@ module.exports = class IdeaThreads extends Collection
     callback(result)
 
   updateIdeaThread: (attributes) ->
+    console.log 'UPDATE'
+    console.log attributes.voting_rights
     existing = @findWhere
       id: attributes.id
     if attributes.deleted
@@ -35,6 +37,8 @@ module.exports = class IdeaThreads extends Collection
     else
       idea_thread = new IdeaThread(attributes)
       rights = idea_thread.get('voting_rights')
+      rights.set(attributes.voting_rights)
+      console.log rights
       right = rights.findWhere
         user_id: Chaplin.mediator.user.get('id')
       if right

--- a/app/models/idea_thread.coffee
+++ b/app/models/idea_thread.coffee
@@ -14,6 +14,7 @@ module.exports = class IdeaThread extends Model
 
   initialize: ->
     super
+    @subscribeEvent 'notifier:update_voting_right', @updateVotingRights
 
     if @isNew()
       current_user_id = Chaplin.mediator.user.get('id')
@@ -31,6 +32,11 @@ module.exports = class IdeaThread extends Model
       if _.isArray(@get('ideas'))
         ideas = new IdeasCollection(@get('ideas'))
         @set 'ideas', ideas
+
+
+  updateVotingRights: (payload) ->
+    if payload.deleted
+      @get('voting_rights').remove(payload.id)
 
 
   total_votes: ->

--- a/app/models/notifier.coffee
+++ b/app/models/notifier.coffee
@@ -52,6 +52,8 @@ module.exports = class Notifier extends Model
         mediator.publish 'notifier:update_comment', payload
       when 'Activity'
         mediator.publish 'notifier:update_activity', payload
+      when 'VotingRight'
+        mediator.publish 'notifier:update_voting_right', payload
 
   createWebNotification: (model_name, payload) ->
     notification = new NotificationCreator(model_name, payload)

--- a/app/models/voting_right.coffee
+++ b/app/models/voting_right.coffee
@@ -6,11 +6,6 @@ module.exports = class VotingRight extends Model
     user_id: null
   urlRoot: ->
     Chaplin.mediator.apiURL('/voting_rights')
-  initialize: ->
-    super
-    @bind 'remove', =>
-      @destroy()
-
 
   toJSON: ->
     new_attr = _.clone(this.attributes)

--- a/app/views/voting_rights/templates/show.hbs
+++ b/app/views/voting_rights/templates/show.hbs
@@ -3,4 +3,8 @@
   {{#unlessCurrentUser user_id }}
     <a href='#' class='remove'>remove</a>
   {{/unlessCurrentUser}}
+{{else}}
+  {{#hasPermission user_id }}
+    <a href='#' class='remove'>remove myself</a>
+  {{/hasPermission}}
 {{/hasPermission}}

--- a/app/views/voting_rights/voting_right_view.coffee
+++ b/app/views/voting_rights/voting_right_view.coffee
@@ -11,4 +11,4 @@ module.exports = class VotingRightView extends View
     @model.set 'thread_user_id', options.idea_thread.get('user_id')
   removeItem: (e) ->
     e.preventDefault()
-    @model.collection.remove @model
+    @model.destroy()


### PR DESCRIPTION
Dependent on https://github.com/cremalab/suite_api/pull/117

Clicking "remove myself" will destroy the associated VotingRight, delete that user's votes in any idea, and remove the IdeaThread from their view.

**Note**: Unbinding `VotingRight#destroy` from its `remove` event and instead just calling `destroy` on the model from the view.
