### PR TITLE
Disabling tuna audio effects. closes #99

### DIFF
--- a/app/lib/audio/bus.coffee
+++ b/app/lib/audio/bus.coffee
@@ -5,39 +5,39 @@ module.exports = class AudioBus
     @input  = context.createGainNode()
     @output = context.createGainNode()
 
-    #create effect nodes (Convolver and Equalizer are other custom effects from the library presented at the end of the article)
-    # delay = new SlapbackDelayNode()
-    # convolver = new tuna.Convolver()
-    # equalizer = new tuna.Equalizer()
-    tuna = new Tuna(context)
+    # Tuna or Safari has a bug where switching audio outputs causes a nasty feedback noise.
+    # Disabling for now.
 
-    delay = new tuna.Delay
-      feedback: .3 #0 to 1+
-      delayTime: 200 #how many milliseconds should the wet signal be delayed?
-      wetLevel: .6 #0 to 1+
-      dryLevel: 1 #0 to 1+
-      cutoff: 800 #cutoff frequency of the built in highpass-filter. 20 to 22050
-      bypass: 0
+    # tuna = new Tuna(context)
 
-    filter = new tuna.Filter(
-      frequency: 1500 #20 to 22050
-      Q: 100 #0.001 to 100
-      gain: -40 #-40 to 40
-      bypass: 0 #0 to 1+
-      filterType: 2 #0 to 7, corresponds to the filter types in the native filter node: lowpass, highpass, bandpass, lowshelf, highshelf, peaking, notch, allpass in that order
-    )
+    # delay = new tuna.Delay
+    #   feedback: .3 #0 to 1+
+    #   delayTime: 200 #how many milliseconds should the wet signal be delayed?
+    #   wetLevel: .6 #0 to 1+
+    #   dryLevel: 1 #0 to 1+
+    #   cutoff: 800 #cutoff frequency of the built in highpass-filter. 20 to 22050
+    #   bypass: 0
 
-    chorus = new tuna.Chorus
-      rate: 10.5
-      feedback: .6
-      delay: 0.085
-      bypass: 0
+    # filter = new tuna.Filter(
+    #   frequency: 1500 #20 to 22050
+    #   Q: 100 #0.001 to 100
+    #   gain: -40 #-40 to 40
+    #   bypass: 0 #0 to 1+
+    #   filterType: 2 #0 to 7, corresponds to the filter types in the native filter node: lowpass, highpass, bandpass, lowshelf, highshelf, peaking, notch, allpass in that order
+    # )
+
+    # chorus = new tuna.Chorus
+    #   rate: 10.5
+    #   feedback: .6
+    #   delay: 0.085
+    #   bypass: 0
 
 
-    @input.connect chorus.input
-    chorus.connect(filter.input)
-    filter.connect(delay.input)
-    delay.connect(@output)
+    # @input.connect chorus.input
+    # chorus.connect(filter.input)
+    # filter.connect(delay.input)
+    # delay.connect(@output)
+    @input.connect(@output)
 
   connect: (target) ->
     @output.connect target


### PR DESCRIPTION
It's either an issue with [Tuna](https://github.com/Dinahmoe/tuna) or with Safari when switching audio outputs. Happens anytime a Tuna instance is created. Bummer. Disabling effects for now until I can write some custom ones and get rid of the Tuna dependency.
